### PR TITLE
lint: fix errors, ignore errcheck for providerserver.Serve

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ docs:
 install:
 	go install .
 
-test:
-	go test -count=1 -parallel=4 ./...
+lint:
+	golangci-lint run
 
 testacc:
 	TF_ACC=1 go test -count=1 -parallel=4 -timeout 10m -v ./...

--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ Generate documentation to `docs/`
 make docs
 ```
 
+Run linters
+
+```shell
+make lint
+```
+
 Run resource tests
 ```shell
 export HOSTINGDE_AUTH_TOKEN=YOUR-API-TOKEN

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
             errcheck
             go-tools
             gnumake
+            golangci-lint
           ];
           bash.extra = ''
           '';

--- a/hostingde/client.go
+++ b/hostingde/client.go
@@ -23,18 +23,21 @@ type Client struct {
 	baseURL    string
 }
 
-func NewClient(authToken, accountId *string) *Client {
-	c := Client{
-		HTTPClient: &http.Client{Timeout: 10 * time.Second},
-		accountId:  *accountId,
-		authToken:  *authToken,
-		baseURL:    defaultBaseURL,
+func NewClient(accountId, authToken *string) *Client {
+	var account, token string
+
+	if accountId != nil {
+		account = *accountId
 	}
 	if authToken != nil {
-		c.authToken = *authToken
+		token = *authToken
 	}
-	if accountId != nil {
-		c.accountId = *accountId
+
+	c := Client{
+		HTTPClient: &http.Client{Timeout: 10 * time.Second},
+		accountId:  account,
+		authToken:  token,
+		baseURL:    defaultBaseURL,
 	}
 
 	return &c

--- a/hostingde/provider.go
+++ b/hostingde/provider.go
@@ -125,8 +125,7 @@ func (p *hostingdeProvider) Configure(ctx context.Context, req provider.Configur
 	tflog.Debug(ctx, "Creating hosting.de client")
 
 	// Create a new hosting.de client using the configuration values
-	client := NewClient(&auth_token, &account_id)
-	//client := NewClient(&account_id, &auth_token)
+	client := NewClient(&account_id, &auth_token)
 
 	// Make the hosting.de client available during DataSource and Resource
 	// type Configure methods.

--- a/hostingde/records.go
+++ b/hostingde/records.go
@@ -28,19 +28,6 @@ func (d *Client) listRecords(findRequest RecordsFindRequest) (*RecordsFindRespon
 	return findResponse, nil
 }
 
-func (d *Client) getRecord(findRequest RecordsFindRequest) (*DNSRecord, error) {
-	var record *DNSRecord
-
-	findResponse, err := d.listRecords(findRequest)
-	if err != nil {
-		return nil, err
-	}
-
-	record = &findResponse.Response.Data[0]
-
-	return record, nil
-}
-
 // https://www.hosting.de/api/?json#updating-records-in-a-zone
 func (c *Client) updateRecords(updateRequest RecordsUpdateRequest) (*RecordsUpdateResponse, error) {
 	uri := defaultBaseURL + "/recordsUpdate"

--- a/hostingde/zone_resource.go
+++ b/hostingde/zone_resource.go
@@ -36,15 +36,6 @@ type zoneResourceModel struct {
 	EMailAddress types.String `tfsdk:"email"`
 }
 
-// zoneSOAResourceModel maps the SOAValues resource schema data.
-type zoneSOAResourceModel struct {
-	Refresh     types.Int64 `tfsdk:"refresh"`
-	Retry       types.Int64 `tfsdk:"retry"`
-	Expire      types.Int64 `tfsdk:"expire"`
-	TTL         types.Int64 `tfsdk:"ttl"`
-	NegativeTTL types.Int64 `tfsdk:"negativeTtl"`
-}
-
 // Metadata returns the resource type name.
 func (r *zoneResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_zone"

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 // Provider documentation generation.
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate --provider-name hostingde
 
+//nolint:errcheck
 func main() {
 	providerserver.Serve(context.Background(), hostingde.New, providerserver.ServeOpts{
 		Address: "registry.terraform.io/pub-solar/hostingde",


### PR DESCRIPTION
```
main.go:15:22: Error return value of `providerserver.Serve` is not checked (errcheck)
	providerserver.Serve(context.Background(), hostingde.New, providerserver.ServeOpts{
	                    ^
hostingde/records.go:31:18: func `(*Client).getRecord` is unused (unused) func (d *Client) getRecord(findRequest RecordsFindRequest) (*DNSRecord, error) {
                 ^
hostingde/zone_resource.go:40:6: type `zoneSOAResourceModel` is unused (unused) type zoneSOAResourceModel struct {
     ^
hostingde/zones.go:14:18: func `(*Client).findZoneConfig` is unused (unused) func (c *Client) findZoneConfig(tfCtx context.Context, findRequest ZoneConfigsFindRequest) (*ZoneConfig, error) {
                 ^
hostingde/zones.go:50:18: func `(*Client).listZoneConfigs` is unused (unused) func (c *Client) listZoneConfigs(findRequest ZoneConfigsFindRequest) (*ZoneConfigsFindResponse, error) {
                 ^
hostingde/zones.go:71:6: func `getZoneConfig` is unused (unused) func getZoneConfig(tfCtx context.Context, zoneId string, c *Client) (*ZoneConfig, error) {
     ^
hostingde/client.go:29:15: SA5011: possible nil pointer dereference (staticcheck)
		accountId:  *accountId,
		            ^
hostingde/client.go:36:5: SA5011(related information): this check suggests that the pointer can be nil (staticcheck)
	if accountId != nil {
	   ^
hostingde/client.go:30:15: SA5011: possible nil pointer dereference (staticcheck)
		authToken:  *authToken,
		            ^
hostingde/client.go:33:5: SA5011(related information): this check suggests that the pointer can be nil (staticcheck)
	if authToken != nil {
	   ^
```