### PR TITLE
fix: make docs needs terraform CLI in PATH

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -71,6 +71,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-2305": {
+      "locked": {
+        "lastModified": 1704290814,
+        "narHash": "sha256-LWvKHp7kGxk/GEtlrGYV68qIvPHkU9iToomNFGagixU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "70bdadeb94ffc8806c0570eb5c2695ad29f0e421",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
@@ -109,7 +125,8 @@
       "inputs": {
         "devshell": "devshell",
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_2",
+        "nixpkgs-2305": "nixpkgs-2305"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,10 +2,11 @@
   description = "hosting.de terraform provider";
 
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  inputs.nixpkgs-2305.url = "github:nixos/nixpkgs/nixos-23.05";
   inputs.devshell.url = "github:numtide/devshell";
   inputs.flake-parts.url = "github:hercules-ci/flake-parts";
 
-  outputs = inputs@{ self, flake-parts, devshell, nixpkgs }:
+  outputs = inputs@{ self, flake-parts, devshell, nixpkgs, nixpkgs-2305 }:
     flake-parts.lib.mkFlake { inherit inputs; } {
       imports = [
         devshell.flakeModule
@@ -25,6 +26,7 @@
             go-tools
             gnumake
             golangci-lint
+            inputs.nixpkgs-2305.legacyPackages.${pkgs.system}.terraform
           ];
           bash.extra = ''
             export GOPATH=~/.local/share/go


### PR DESCRIPTION
- Use terraform 1.5.x, last version with open source MPL license

```
❯ make docs
go generate ./...
rendering website for provider "hostingde" (as "hostingde")
copying any existing content to tmp dir
exporting schema from Terraform
compiling provider "hostingde"
using Terraform CLI binary from PATH if available, otherwise downloading latest Terraform CLI binary
```