### PR TITLE
feat: add option for base URL

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ Currently only supports maintaining DNS zones and records.
 **Environment variables for provider configuration**
 - Required: `HOSTINGDE_AUTH_TOKEN`, go to your [hosting.de profile](https://secure.hosting.de/profile) and create an API Key (token)
 - Optional: `HOSTINGDE_ACCOUNT_ID`
+- Optional: `HOSTINGDE_BASE_URL`
 
 Before continuing, make sure you have created an API token with DNS permissions
 and allow-listed your [external IP address](https://wieistmeineip.de/).
@@ -44,3 +45,4 @@ provider "hostingde" {
 
 - `account_id` (String) Account ID for hosting.de API. May also be provided via HOSTINGDE_ACCOUNT_ID environment variable.
 - `auth_token` (String, Sensitive) Auth token for hosting.de API. May also be provided via HOSTINGDE_AUTH_TOKEN environment variable.
+- `base_url` (String) Base URL for hosting.de API. May also be provided via HOSTINGDE_BASE_URL environment variable.

--- a/hostingde/client.go
+++ b/hostingde/client.go
@@ -13,8 +13,6 @@ import (
 	"time"
 )
 
-const defaultBaseURL = "https://secure.hosting.de/api/dns/v1/json"
-
 // Client -
 type Client struct {
 	HTTPClient *http.Client
@@ -23,8 +21,8 @@ type Client struct {
 	baseURL    string
 }
 
-func NewClient(accountId, authToken *string) *Client {
-	var account, token string
+func NewClient(accountId, authToken, baseUrl *string) *Client {
+	var account, token, url string
 
 	if accountId != nil {
 		account = *accountId
@@ -32,12 +30,15 @@ func NewClient(accountId, authToken *string) *Client {
 	if authToken != nil {
 		token = *authToken
 	}
+	if baseUrl != nil {
+		url = *baseUrl
+	}
 
 	c := Client{
 		HTTPClient: &http.Client{Timeout: 10 * time.Second},
 		accountId:  account,
 		authToken:  token,
-		baseURL:    defaultBaseURL,
+		baseURL:    url,
 	}
 
 	return &c

--- a/hostingde/provider.go
+++ b/hostingde/provider.go
@@ -13,6 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
+const defaultBaseURL = "https://secure.hosting.de/api/dns/v1/json"
+
 // Ensure the implementation satisfies the expected interfaces
 var (
 	_ provider.Provider = &hostingdeProvider{}
@@ -114,7 +116,7 @@ func (p *hostingdeProvider) Configure(ctx context.Context, req provider.Configur
 
 	// Default for API Base URL
 	if base_url == "" {
-		base_url = "https://secure.hosting.de/api/dns/v1/json"
+		base_url = defaultBaseURL
 	}
 
 	// If any of the expected configurations are missing, return

--- a/hostingde/records.go
+++ b/hostingde/records.go
@@ -8,7 +8,7 @@ import (
 
 // https://www.hosting.de/api/?json#list-recordconfigs
 func (d *Client) listRecords(findRequest RecordsFindRequest) (*RecordsFindResponse, error) {
-	uri := defaultBaseURL + "/recordsFind"
+	uri := d.baseURL + "/recordsFind"
 
 	findResponse := &RecordsFindResponse{}
 
@@ -30,7 +30,7 @@ func (d *Client) listRecords(findRequest RecordsFindRequest) (*RecordsFindRespon
 
 // https://www.hosting.de/api/?json#updating-records-in-a-zone
 func (c *Client) updateRecords(updateRequest RecordsUpdateRequest) (*RecordsUpdateResponse, error) {
-	uri := defaultBaseURL + "/recordsUpdate"
+	uri := c.baseURL + "/recordsUpdate"
 
 	updateResponse := &RecordsUpdateResponse{}
 

--- a/hostingde/zones.go
+++ b/hostingde/zones.go
@@ -8,7 +8,7 @@ import (
 
 // https://www.hosting.de/api/?json#listing-zones
 func (c *Client) listZones(findRequest ZonesFindRequest) (*ZonesFindResponse, error) {
-	uri := defaultBaseURL + "/zonesFind"
+	uri := c.baseURL + "/zonesFind"
 
 	findResponse := &ZonesFindResponse{}
 
@@ -30,7 +30,7 @@ func (c *Client) listZones(findRequest ZonesFindRequest) (*ZonesFindResponse, er
 
 // https://www.hosting.de/api/?json#creating-new-zones
 func (c *Client) createZone(createRequest ZoneCreateRequest) (*ZoneCreateResponse, error) {
-	uri := defaultBaseURL + "/zoneCreate"
+	uri := c.baseURL + "/zoneCreate"
 
 	createResponse := &ZoneCreateResponse{}
 
@@ -48,7 +48,7 @@ func (c *Client) createZone(createRequest ZoneCreateRequest) (*ZoneCreateRespons
 
 // https://www.hosting.de/api/?json#updating-zones
 func (c *Client) updateZone(updateRequest ZoneUpdateRequest) (*ZoneUpdateResponse, error) {
-	uri := defaultBaseURL + "/zoneUpdate"
+	uri := c.baseURL + "/zoneUpdate"
 
 	updateResponse := &ZoneUpdateResponse{}
 
@@ -66,7 +66,7 @@ func (c *Client) updateZone(updateRequest ZoneUpdateRequest) (*ZoneUpdateRespons
 
 // https://www.hosting.de/api/?json#deleting-zones
 func (c *Client) deleteZone(deleteRequest ZoneDeleteRequest) (*ZoneDeleteResponse, error) {
-	uri := defaultBaseURL + "/zoneDelete"
+	uri := c.baseURL + "/zoneDelete"
 
 	deleteResponse := &ZoneDeleteResponse{}
 
@@ -84,7 +84,7 @@ func (c *Client) deleteZone(deleteRequest ZoneDeleteRequest) (*ZoneDeleteRespons
 
 // https://www.hosting.de/api/?json#purging-zones
 func (c *Client) purgeZone(purgeRequest ZoneDeleteRequest) (*ZoneDeleteResponse, error) {
-	uri := defaultBaseURL + "/zonePurgeRestorable"
+	uri := c.baseURL + "/zonePurgeRestorable"
 
 	purgeResponse := &ZoneDeleteResponse{}
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -15,6 +15,7 @@ Currently only supports maintaining DNS zones and records.
 **Environment variables for provider configuration**
 - Required: `HOSTINGDE_AUTH_TOKEN`, go to your [hosting.de profile](https://secure.hosting.de/profile) and create an API Key (token)
 - Optional: `HOSTINGDE_ACCOUNT_ID`
+- Optional: `HOSTINGDE_BASE_URL`
 
 Before continuing, make sure you have created an API token with DNS permissions
 and allow-listed your [external IP address](https://wieistmeineip.de/).
@@ -34,3 +35,4 @@ and allow-listed your [external IP address](https://wieistmeineip.de/).
 
 - `account_id` (String) Account ID for hosting.de API. May also be provided via HOSTINGDE_ACCOUNT_ID environment variable.
 - `auth_token` (String, Sensitive) Auth token for hosting.de API. May also be provided via HOSTINGDE_AUTH_TOKEN environment variable.
+- `base_url` (String) Base URL for hosting.de API. May also be provided via HOSTINGDE_BASE_URL environment variable.


### PR DESCRIPTION
Since hosting.de and http.net share the same API (see https://www.http.net/docs/api/?json), this PR is meant to be able to use this provider for http.net as well. Unfortunately, I have only limited experience with Go - if any of the approaches are wrong/inappropriate I would be happy to receive feedback.